### PR TITLE
Fix workflow conditional closure

### DIFF
--- a/.github/workflows/rss.yml
+++ b/.github/workflows/rss.yml
@@ -45,3 +45,4 @@ jobs:
             git push
           else
             echo "No changes to commit."
+          fi


### PR DESCRIPTION
## Summary
- add the missing `fi` to close the conditional in the RSS workflow

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d54dc3a28c832fba0112f8b910b67c